### PR TITLE
Add backend and frontend testing setup

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon src/index.ts",
     "build": "tsc",
     "test": "jest",
+    "test:watch": "jest --watch",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "init-db": "ts-node src/config/init-db.ts",
@@ -46,8 +47,11 @@
     "eslint": "^8.54.0",
     "jest": "^29.7.0",
     "@types/jest": "^29.5.8",
+    "@types/supertest": "^2.0.12",
     "nodemon": "^3.0.2",
+    "supertest": "^6.3.3",
     "ts-node": "^10.9.1",
+    "ts-jest": "^29.1.1",
     "typescript": "^5.3.2"
   },
   "engines": {

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -1,0 +1,26 @@
+import request from 'supertest';
+import express from 'express';
+import authRouter from '../src/routes/auth';
+
+const app = express();
+app.use(express.json());
+app.use('/api/auth', authRouter);
+
+describe('Auth routes', () => {
+  it('logs in with valid credentials', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'inspector@example.com', password: 'password' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.token).toBeTruthy();
+  });
+
+  it('rejects invalid credentials', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'inspector@example.com', password: 'wrong' });
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+});

--- a/backend/tests/tasks.test.ts
+++ b/backend/tests/tasks.test.ts
@@ -1,0 +1,34 @@
+import request from 'supertest';
+import express from 'express';
+
+jest.mock('../src/config/database', () => ({
+  query: jest.fn(),
+}));
+
+import pool from '../src/config/database';
+import tasksRouter from '../src/routes/tasks';
+
+const app = express();
+app.use(express.json());
+app.use('/api/tasks', tasksRouter);
+
+describe('Tasks routes', () => {
+  afterEach(() => {
+    (pool.query as jest.Mock).mockReset();
+  });
+
+  it('returns a task by id', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ id: '1', description: 'Test' }] });
+    const res = await request(app).get('/api/tasks/1');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual({ id: '1', description: 'Test' });
+  });
+
+  it('returns 404 when task not found', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    const res = await request(app).get('/api/tasks/2');
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,8 @@
     "start": "react-scripts start",
     "dev": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
+    "test:watch": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/frontend/src/__tests__/HomeSelector.test.tsx
+++ b/frontend/src/__tests__/HomeSelector.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HomeSelector from '../components/HomeSelector/HomeSelector';
+
+jest.mock('../contexts/HomeContext', () => ({
+  useHome: jest.fn(),
+}));
+
+const mockUseHome = require('../contexts/HomeContext').useHome as jest.Mock;
+
+describe('HomeSelector', () => {
+  it('shows placeholder when no homes available', () => {
+    mockUseHome.mockReturnValue({
+      selectedHome: null,
+      homes: [],
+      loading: false,
+      setSelectedHome: jest.fn(),
+    });
+    render(<HomeSelector />);
+    expect(screen.getByText(/No homes available/i)).toBeInTheDocument();
+  });
+
+  it('renders selected home chip', () => {
+    mockUseHome.mockReturnValue({
+      selectedHome: { id: '1', name: 'Home A' },
+      homes: [{ id: '1', name: 'Home A' }],
+      loading: false,
+      setSelectedHome: jest.fn(),
+    });
+    render(<HomeSelector />);
+    expect(screen.getAllByText('Home A').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/Login.test.tsx
+++ b/frontend/src/__tests__/Login.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Login from '../pages/Login/Login';
+
+jest.mock('../contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockUseAuth = require('../contexts/AuthContext').useAuth as jest.Mock;
+
+describe('Login page', () => {
+  it('submits credentials', async () => {
+    const login = jest.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({ login });
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByLabelText(/Email/i), { target: { value: 'user@example.com' } });
+    fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    await waitFor(() => expect(login).toHaveBeenCalledWith('user@example.com', 'secret'));
+  });
+});

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add Jest config and tests for backend auth and task routes
- add React Testing Library tests for HomeSelector and Login page
- expose test commands for backend and frontend

## Testing
- `cd backend && npm test` *(fails: Preset ts-jest not found)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f580d682883209410a97569773ab9