### PR TITLE
feat: validate environment variables

### DIFF
--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,17 +1,15 @@
 import { Pool } from 'pg';
-import dotenv from 'dotenv';
-
-dotenv.config();
+import env from './env';
 
 // Database configuration
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  host: process.env.DB_HOST || 'localhost',
-  port: parseInt(process.env.DB_PORT || '5432'),
-  database: process.env.DB_NAME || 'fire_door_inspection',
-  user: process.env.DB_USER || 'postgres',
-  password: process.env.DB_PASSWORD || 'password',
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  connectionString: env.DATABASE_URL,
+  host: env.DB_HOST,
+  port: env.DB_PORT,
+  database: env.DB_NAME,
+  user: env.DB_USER,
+  password: env.DB_PASSWORD,
+  ssl: env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
 });
 
 // Test database connection

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,38 @@
+import dotenv from 'dotenv';
+import Joi from 'joi';
+
+dotenv.config();
+
+const envSchema = Joi.object({
+  NODE_ENV: Joi.string().valid('development', 'test', 'production').default('development'),
+  PORT: Joi.number().port().default(5000),
+  FRONTEND_URL: Joi.string().uri().default('http://localhost:3000'),
+  DATABASE_URL: Joi.string().uri().required(),
+  DB_HOST: Joi.string().default('localhost'),
+  DB_PORT: Joi.number().port().default(5432),
+  DB_NAME: Joi.string().default('fire_door_inspection'),
+  DB_USER: Joi.string().default('postgres'),
+  DB_PASSWORD: Joi.string().required(),
+  JWT_SECRET: Joi.string().required(),
+  DEBUG_PDF: Joi.boolean().optional(),
+}).unknown();
+
+const { value: envVars, error } = envSchema.validate(process.env, { abortEarly: false });
+
+if (error) {
+  throw new Error(`Config validation error: ${error.message}`);
+}
+
+export default envVars as {
+  NODE_ENV: 'development' | 'test' | 'production';
+  PORT: number;
+  FRONTEND_URL: string;
+  DATABASE_URL: string;
+  DB_HOST: string;
+  DB_PORT: number;
+  DB_NAME: string;
+  DB_USER: string;
+  DB_PASSWORD: string;
+  JWT_SECRET: string;
+  DEBUG_PDF?: boolean;
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,7 +4,6 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import compression from 'compression';
 import rateLimit from 'express-rate-limit';
-import dotenv from 'dotenv';
 import path from 'path';
 
 import { errorHandler } from './middleware/errorHandler';
@@ -20,19 +19,17 @@ import userRoutes from './routes/users';
 import remediationReportRoutes from './routes/remediation-reports';
 import homeRoutes from './routes/homes';
 import initializeDatabase from './config/init-db';
-
-// Load environment variables
-dotenv.config();
+import env from './config/env';
 
 const app = express();
-const PORT = process.env.PORT || 5000;
+const PORT = env.PORT;
 
 // Security middleware
 app.use(helmet());
 
 // CORS configuration
 app.use(cors({
-  origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+  origin: env.FRONTEND_URL,
   credentials: true,
 }));
 
@@ -52,7 +49,7 @@ app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 app.use(compression());
 
 // Logging middleware
-if (process.env.NODE_ENV !== 'test') {
+if (env.NODE_ENV !== 'test') {
   app.use(morgan('combined'));
 }
 

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import Joi from 'joi';
+import env from '../config/env';
 
 const router = express.Router();
 
@@ -66,7 +67,7 @@ router.post('/login', async (req, res) => {
     // Create token
     const token = jwt.sign(
       { userId: user.id, email: user.email, role: user.role },
-      process.env.JWT_SECRET || 'your-secret-key',
+      env.JWT_SECRET,
       { expiresIn: '24h' }
     );
 
@@ -103,7 +104,7 @@ router.get('/me', async (req, res) => {
       });
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key') as any;
+    const decoded = jwt.verify(token, env.JWT_SECRET) as any;
     const user = mockUsers.find(u => u.id === decoded.userId);
 
     if (!user) {


### PR DESCRIPTION
## Summary
- add Joi-based schema for environment variable validation
- remove insecure DB and JWT defaults and use config across app

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f583b68a88320bc2d1a02ad735143