### PR TITLE
refactor: add async error handling utility

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import Joi from 'joi';
+import asyncHandler from '../utils/asyncHandler';
 
 const router = express.Router();
 
@@ -32,8 +33,7 @@ const mockUsers = [
 // @route   POST /api/auth/login
 // @desc    Authenticate user & get token
 // @access  Public
-router.post('/login', async (req, res) => {
-  try {
+router.post('/login', asyncHandler(async (req, res) => {
     // Validate input
     const { error, value } = loginSchema.validate(req.body);
     if (error) {
@@ -80,20 +80,12 @@ router.post('/login', async (req, res) => {
         role: user.role,
       },
     });
-  } catch (error) {
-    console.error('Login error:', error);
-    return res.status(500).json({
-      success: false,
-      error: 'Server error',
-    });
-  }
-});
+}));
 
 // @route   GET /api/auth/me
 // @desc    Get current user
 // @access  Private
-router.get('/me', async (req, res) => {
-  try {
+router.get('/me', asyncHandler(async (req, res) => {
     const token = req.header('Authorization')?.replace('Bearer ', '');
 
     if (!token) {
@@ -122,13 +114,6 @@ router.get('/me', async (req, res) => {
         role: user.role,
       },
     });
-  } catch (error) {
-    console.error('Auth error:', error);
-    return res.status(401).json({
-      success: false,
-      error: 'Token is not valid',
-    });
-  }
-});
+}));
 
 export default router; 

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import Joi from 'joi';
 import pool from '../config/database';
+import asyncHandler from '../utils/asyncHandler';
 
 const router = express.Router();
 
@@ -25,8 +26,7 @@ const updateTaskSchema = Joi.object({
 // @route   GET /api/tasks
 // @desc    Get all tasks
 // @access  Private
-router.get('/', async (req, res) => {
-  try {
+router.get('/', asyncHandler(async (req, res) => {
     const { status, priority, inspectionId, home_id, page = 1, limit = 10 } = req.query;
     
     let query = `
@@ -88,22 +88,14 @@ router.get('/', async (req, res) => {
         itemsPerPage: Number(limit),
       },
     });
-  } catch (error) {
-    console.error('Get tasks error:', error);
-    return res.status(500).json({
-      success: false,
-      error: 'Server error',
-    });
-  }
-});
+}));
 
 // @route   GET /api/tasks/:id
 // @desc    Get task by ID
 // @access  Private
-router.get('/:id', async (req, res) => {
-  try {
+router.get('/:id', asyncHandler(async (req, res) => {
     const { rows } = await pool.query('SELECT * FROM tasks WHERE id = $1', [req.params.id]);
-    
+
     if (rows.length === 0) {
       return res.status(404).json({
         success: false,
@@ -115,20 +107,12 @@ router.get('/:id', async (req, res) => {
       success: true,
       data: rows[0],
     });
-  } catch (error) {
-    console.error('Get task error:', error);
-    return res.status(500).json({
-      success: false,
-      error: 'Server error',
-    });
-  }
-});
+}));
 
 // @route   POST /api/tasks
 // @desc    Create new task
 // @access  Private
-router.post('/', async (req, res) => {
-  try {
+router.post('/', asyncHandler(async (req, res) => {
     const { error, value } = createTaskSchema.validate(req.body);
     if (error) {
       return res.status(400).json({
@@ -158,20 +142,12 @@ router.post('/', async (req, res) => {
       success: true,
       data: newTask,
     });
-  } catch (error) {
-    console.error('Create task error:', error);
-    return res.status(500).json({
-      success: false,
-      error: 'Server error',
-    });
-  }
-});
+}));
 
 // @route   PUT /api/tasks/:id
 // @desc    Update task
 // @access  Private
-router.put('/:id', async (req, res) => {
-  try {
+router.put('/:id', asyncHandler(async (req, res) => {
     const { error, value } = updateTaskSchema.validate(req.body);
     if (error) {
       return res.status(400).json({
@@ -210,7 +186,7 @@ router.put('/:id', async (req, res) => {
 
     params.push(req.params.id);
     const { rows } = await pool.query(`
-      UPDATE tasks 
+      UPDATE tasks
       SET ${updateFields.join(', ')}, updated_at = NOW()
       WHERE id = $${paramCount}
       RETURNING *
@@ -227,22 +203,14 @@ router.put('/:id', async (req, res) => {
       success: true,
       data: rows[0],
     });
-  } catch (error) {
-    console.error('Update task error:', error);
-    return res.status(500).json({
-      success: false,
-      error: 'Server error',
-    });
-  }
-});
+}));
 
 // @route   DELETE /api/tasks/:id
 // @desc    Delete task
 // @access  Private
-router.delete('/:id', async (req, res) => {
-  try {
+router.delete('/:id', asyncHandler(async (req, res) => {
     const { rowCount } = await pool.query('DELETE FROM tasks WHERE id = $1', [req.params.id]);
-    
+
     if (rowCount === 0) {
       return res.status(404).json({
         success: false,
@@ -254,13 +222,6 @@ router.delete('/:id', async (req, res) => {
       success: true,
       message: 'Task deleted successfully',
     });
-  } catch (error) {
-    console.error('Delete task error:', error);
-    return res.status(500).json({
-      success: false,
-      error: 'Server error',
-    });
-  }
-});
+}));
 
 export default router; 

--- a/backend/src/utils/asyncHandler.ts
+++ b/backend/src/utils/asyncHandler.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+// Utility to wrap async route handlers and forward errors to Express error middleware
+const asyncHandler = (
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<any>
+): RequestHandler => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+
+export default asyncHandler;


### PR DESCRIPTION
## Summary
- add asyncHandler utility to wrap async route handlers
- refactor auth and task routes to use asyncHandler
- rely on centralized error middleware for uncaught errors

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f583c7dcc8320a018a06a3da60b95