### PR TITLE
refactor: remove any types and unused state

### DIFF
--- a/frontend/src/components/HomeSelector/HomeSelector.tsx
+++ b/frontend/src/components/HomeSelector/HomeSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Box,
   FormControl,
@@ -6,20 +6,18 @@ import {
   MenuItem,
   Typography,
   Chip,
-  IconButton,
-  Tooltip,
 } from '@mui/material';
 import {
   Home as HomeIcon,
   Business as BusinessIcon,
 } from '@mui/icons-material';
 import { useHome } from '../../contexts/HomeContext';
+import { SelectChangeEvent } from '@mui/material/Select';
 
 const HomeSelector: React.FC = () => {
   const { selectedHome, homes, loading, setSelectedHome } = useHome();
-  const [open, setOpen] = useState(false);
 
-  const handleHomeChange = (event: any) => {
+  const handleHomeChange = (event: SelectChangeEvent<string>) => {
     const homeId = event.target.value;
     const home = homes.find(h => h.id === homeId);
     setSelectedHome(home || null);

--- a/frontend/src/components/PDFUploadDialog/PDFUploadDialog.tsx
+++ b/frontend/src/components/PDFUploadDialog/PDFUploadDialog.tsx
@@ -26,17 +26,35 @@ import {
   Info as InfoIcon,
 } from '@mui/icons-material';
 import { useDropzone } from 'react-dropzone';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
+import type { ChipProps } from '@mui/material';
+
+interface UploadedInspection {
+  location: string;
+  inspector_name: string;
+  date: string;
+  notes?: string;
+}
+
+interface UploadedTask {
+  doorId: string;
+  location: string;
+  title: string;
+  description: string;
+  category: string;
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  status: 'pending' | 'in-progress' | 'completed' | 'cancelled';
+}
 
 interface PDFUploadDialogProps {
   open: boolean;
   onClose: () => void;
-  onSuccess: (inspection: any, tasks: any[]) => void;
+  onSuccess: (inspection: UploadedInspection, tasks: UploadedTask[]) => void;
 }
 
 interface ExtractedData {
-  inspection: any;
-  tasks: any[];
+  inspection: UploadedInspection;
+  tasks: UploadedTask[];
   summary: {
     totalDoors: number;
     compliantDoors: number;
@@ -51,6 +69,7 @@ interface ExtractedData {
   extractedText: string;
   totalPages: number;
 }
+
 
 const PDFUploadDialog: React.FC<PDFUploadDialogProps> = ({
   open,
@@ -80,11 +99,12 @@ const PDFUploadDialog: React.FC<PDFUploadDialogProps> = ({
       });
 
       setExtractedData(response.data);
-    } catch (err: any) {
-      console.error('PDF upload error:', err);
+    } catch (err) {
+      const error = err as AxiosError<{ error?: string; details?: string }>;
+      console.error('PDF upload error:', error);
       setError(
-        err.response?.data?.error || 
-        err.response?.data?.details || 
+        error.response?.data?.error ||
+        error.response?.data?.details ||
         'Failed to upload and process PDF'
       );
     } finally {
@@ -114,7 +134,7 @@ const PDFUploadDialog: React.FC<PDFUploadDialogProps> = ({
     onClose();
   };
 
-  const getPriorityColor = (priority: string) => {
+  const getPriorityColor = (priority: string): ChipProps['color'] => {
     switch (priority) {
       case 'critical':
         return 'error';
@@ -289,7 +309,7 @@ const PDFUploadDialog: React.FC<PDFUploadDialogProps> = ({
                           <Chip 
                             label={task.priority} 
                             size="small" 
-                            color={getPriorityColor(task.priority) as any}
+                            color={getPriorityColor(task.priority)}
                             sx={{ mr: 1 }}
                           />
                           {task.category && (

--- a/frontend/src/pages/Inspections/Inspections.tsx
+++ b/frontend/src/pages/Inspections/Inspections.tsx
@@ -45,6 +45,16 @@ interface Inspection {
   notes: string;
 }
 
+interface UploadedTask {
+  doorId: string;
+  location: string;
+  title: string;
+  description: string;
+  category: string;
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  status: 'pending' | 'in-progress' | 'completed' | 'cancelled';
+}
+
 const Inspections: React.FC = () => {
   const { user } = useAuth();
   const { selectedHome } = useHome();
@@ -177,7 +187,7 @@ const Inspections: React.FC = () => {
     }
   };
 
-  const handlePDFUploadSuccess = (inspection: Inspection, tasks: any[]) => {
+  const handlePDFUploadSuccess = (_inspection: Inspection, _tasks: UploadedTask[]) => {
     // Refresh the inspections list to show the new inspection
     fetchInspections();
     setOpenPDFDialog(false);

--- a/frontend/src/pages/RemediationReports/RemediationReports.tsx
+++ b/frontend/src/pages/RemediationReports/RemediationReports.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
+
+type JsPDFWithAutoTable = jsPDF & { lastAutoTable?: { finalY: number } };
 import {
   Box,
   Typography,
@@ -67,8 +69,27 @@ interface Task {
   inspection_location: string;
   inspector_name: string;
   inspection_date: string;
-  photos: any[];
-  rejections: any[];
+  photos: TaskPhoto[];
+  rejections: TaskRejection[];
+}
+
+interface TaskPhoto {
+  id: string;
+  task_id: string;
+  photo_type: string;
+  description: string;
+  photo_url: string;
+  created_at: string;
+  uploaded_by_name: string;
+}
+
+interface TaskRejection {
+  id: string;
+  task_id: string;
+  rejection_reason: string;
+  alternative_suggestion: string;
+  created_at: string;
+  rejected_by_name: string;
 }
 
 interface RemediationReport {
@@ -383,7 +404,7 @@ PRIORITY BREAKDOWN
   const exportAsPDF = async () => {
     if (!report) return;
     
-    const doc = new jsPDF();
+    const doc: JsPDFWithAutoTable = new jsPDF();
     let yPosition = 20;
     
     // Title
@@ -445,7 +466,7 @@ PRIORITY BREAKDOWN
        styles: { fontSize: 9 }
      });
      
-     yPosition = (doc as any).lastAutoTable.finalY + 15;
+     yPosition = (doc.lastAutoTable?.finalY ?? yPosition) + 15;
     
     // Category Performance Table
     doc.setFontSize(14);
@@ -469,7 +490,7 @@ PRIORITY BREAKDOWN
        styles: { fontSize: 9 }
      });
      
-     yPosition = (doc as any).lastAutoTable.finalY + 15;
+     yPosition = (doc.lastAutoTable?.finalY ?? yPosition) + 15;
     
     // Location Performance Table
     doc.setFontSize(14);
@@ -493,7 +514,7 @@ PRIORITY BREAKDOWN
        styles: { fontSize: 9 }
      });
      
-     yPosition = (doc as any).lastAutoTable.finalY + 15;
+     yPosition = (doc.lastAutoTable?.finalY ?? yPosition) + 15;
     
     // Recent Activity
     doc.setFontSize(14);

--- a/frontend/src/pages/Reports/Reports.tsx
+++ b/frontend/src/pages/Reports/Reports.tsx
@@ -29,6 +29,7 @@ import {
   Visibility as ViewIcon,
   Assessment as AssessmentIcon,
 } from '@mui/icons-material';
+import type { ChipProps } from '@mui/material';
 
 interface Report {
   id: string;
@@ -228,7 +229,7 @@ const Reports: React.FC = () => {
     }
   };
 
-  const getSeverityColor = (severity: string) => {
+  const getSeverityColor = (severity: string): ChipProps['color'] => {
     switch (severity) {
       case 'critical':
         return 'error';
@@ -430,7 +431,7 @@ const Reports: React.FC = () => {
                         </Typography>
                         <Chip
                           label={finding.severity}
-                          color={getSeverityColor(finding.severity) as any}
+                          color={getSeverityColor(finding.severity)}
                           size="small"
                         />
                       </Box>

--- a/frontend/src/pages/Tasks/Tasks.tsx
+++ b/frontend/src/pages/Tasks/Tasks.tsx
@@ -34,6 +34,7 @@ import {
 import { useAuth } from '../../contexts/AuthContext';
 import { useHome } from '../../contexts/HomeContext';
 import axios from 'axios';
+import { SelectChangeEvent } from '@mui/material/Select';
 
 interface Task {
   id: string;
@@ -457,7 +458,9 @@ const Tasks: React.FC = () => {
                 <Select
                   value={filters.status}
                   label="Status"
-                  onChange={(e) => setFilters({ ...filters, status: e.target.value as any })}
+                  onChange={(e: SelectChangeEvent<'all' | Task['status']>) =>
+                    setFilters({ ...filters, status: e.target.value })
+                  }
                 >
                   <MenuItem value="all">All Statuses</MenuItem>
                   <MenuItem value="pending">Pending</MenuItem>
@@ -474,7 +477,9 @@ const Tasks: React.FC = () => {
                 <Select
                   value={filters.priority}
                   label="Priority"
-                  onChange={(e) => setFilters({ ...filters, priority: e.target.value as any })}
+                  onChange={(e: SelectChangeEvent<'all' | Task['priority']>) =>
+                    setFilters({ ...filters, priority: e.target.value })
+                  }
                 >
                   <MenuItem value="all">All Priorities</MenuItem>
                   <MenuItem value="low">Low</MenuItem>

--- a/frontend/src/pages/WorkmenTasks/WorkmenTasks.tsx
+++ b/frontend/src/pages/WorkmenTasks/WorkmenTasks.tsx
@@ -41,6 +41,8 @@ import {
   VisibilityOff
 } from '@mui/icons-material';
 import axios from 'axios';
+import { SelectChangeEvent } from '@mui/material/Select';
+import type { ChipProps } from '@mui/material';
 
 interface Task {
   id: string;
@@ -220,23 +222,33 @@ const WorkmenTasks: React.FC = () => {
     }
   };
 
-  const getPriorityColor = (priority: string) => {
+  const getPriorityColor = (priority: string): ChipProps['color'] => {
     switch (priority) {
-      case 'critical': return 'error';
-      case 'high': return 'warning';
-      case 'medium': return 'info';
-      case 'low': return 'success';
-      default: return 'default';
+      case 'critical':
+        return 'error';
+      case 'high':
+        return 'warning';
+      case 'medium':
+        return 'info';
+      case 'low':
+        return 'success';
+      default:
+        return 'default';
     }
   };
 
-  const getStatusColor = (status: string) => {
+  const getStatusColor = (status: string): ChipProps['color'] => {
     switch (status) {
-      case 'completed': return 'success';
-      case 'in-progress': return 'info';
-      case 'rejected': return 'error';
-      case 'cancelled': return 'default';
-      default: return 'warning';
+      case 'completed':
+        return 'success';
+      case 'in-progress':
+        return 'info';
+      case 'rejected':
+        return 'error';
+      case 'cancelled':
+        return 'default';
+      default:
+        return 'warning';
     }
   };
 
@@ -300,7 +312,9 @@ const WorkmenTasks: React.FC = () => {
                   <Select
                     value={filters.status}
                     label="Status"
-                    onChange={(e) => setFilters({ ...filters, status: e.target.value as any })}
+                    onChange={(e: SelectChangeEvent<'all' | Task['status']>) =>
+                      setFilters({ ...filters, status: e.target.value })
+                    }
                   >
                     <MenuItem value="all">All Statuses</MenuItem>
                     <MenuItem value="pending">Pending</MenuItem>
@@ -317,7 +331,9 @@ const WorkmenTasks: React.FC = () => {
                   <Select
                     value={filters.priority}
                     label="Priority"
-                    onChange={(e) => setFilters({ ...filters, priority: e.target.value as any })}
+                    onChange={(e: SelectChangeEvent<'all' | Task['priority']>) =>
+                      setFilters({ ...filters, priority: e.target.value })
+                    }
                   >
                     <MenuItem value="all">All Priorities</MenuItem>
                     <MenuItem value="low">Low</MenuItem>
@@ -397,14 +413,14 @@ const WorkmenTasks: React.FC = () => {
                   primary={
                     <Box display="flex" alignItems="center" gap={1}>
                       <Typography variant="h6">{task.title}</Typography>
-                      <Chip 
-                        label={task.priority} 
-                        color={getPriorityColor(task.priority) as any}
+                      <Chip
+                        label={task.priority}
+                        color={getPriorityColor(task.priority)}
                         size="small"
                       />
-                      <Chip 
-                        label={task.status} 
-                        color={getStatusColor(task.status) as any}
+                      <Chip
+                        label={task.status}
+                        color={getStatusColor(task.status)}
                         size="small"
                       />
                     </Box>
@@ -568,8 +584,8 @@ const WorkmenTasks: React.FC = () => {
               <Typography variant="body1" paragraph>{selectedTask.description}</Typography>
               
               <Box display="flex" gap={1} mb={2}>
-                <Chip label={selectedTask.priority} color={getPriorityColor(selectedTask.priority) as any} />
-                <Chip label={selectedTask.status} color={getStatusColor(selectedTask.status) as any} />
+                <Chip label={selectedTask.priority} color={getPriorityColor(selectedTask.priority)} />
+                <Chip label={selectedTask.status} color={getStatusColor(selectedTask.status)} />
               </Box>
               
               <Typography variant="body2" color="textSecondary" gutterBottom>


### PR DESCRIPTION
## Summary
- use MUI `SelectChangeEvent` in `HomeSelector` and filter menus
- introduce explicit interfaces for uploaded data and remediation reports
- eliminate `any` casts and unused state across components

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`
- `npm test --prefix backend -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f58400b188320a7d2df9b8d10b46d