### PR TITLE
Add Node types to backend TypeScript config

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -21,6 +21,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
+    "types": ["node"],
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## Summary
- include Node typings in backend tsconfig for better type resolution

## Testing
- `npm install`
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3172484588320936581974bbaa9a0