### PR TITLE
chore: type express route handlers

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import Joi from 'joi';
@@ -32,7 +32,7 @@ const mockUsers = [
 // @route   POST /api/auth/login
 // @desc    Authenticate user & get token
 // @access  Public
-router.post('/login', async (req, res) => {
+router.post('/login', async (req: Request, res: Response) => {
   try {
     // Validate input
     const { error, value } = loginSchema.validate(req.body);
@@ -92,7 +92,7 @@ router.post('/login', async (req, res) => {
 // @route   GET /api/auth/me
 // @desc    Get current user
 // @access  Private
-router.get('/me', async (req, res) => {
+router.get('/me', async (req: Request, res: Response) => {
   try {
     const token = req.header('Authorization')?.replace('Bearer ', '');
 

--- a/backend/src/routes/homes.ts
+++ b/backend/src/routes/homes.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import pool from '../config/database';
 import Joi from 'joi';
 
@@ -22,7 +22,7 @@ const updateHomeSchema = Joi.object({
 });
 
 // GET /api/homes - Get all homes
-router.get('/', async (req, res) => {
+router.get('/', async (req: Request, res: Response) => {
   try {
     const { rows: homes } = await pool.query(`
       SELECT * FROM homes 
@@ -37,7 +37,7 @@ router.get('/', async (req, res) => {
 });
 
 // GET /api/homes/:id - Get home by ID
-router.get('/:id', async (req, res) => {
+router.get('/:id', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     
@@ -58,7 +58,7 @@ router.get('/:id', async (req, res) => {
 });
 
 // POST /api/homes - Create new home
-router.post('/', async (req, res) => {
+router.post('/', async (req: Request, res: Response) => {
   try {
     const { error, value } = createHomeSchema.validate(req.body);
     if (error) {
@@ -88,7 +88,7 @@ router.post('/', async (req, res) => {
 });
 
 // PUT /api/homes/:id - Update home
-router.put('/:id', async (req, res) => {
+router.put('/:id', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const { error, value } = updateHomeSchema.validate(req.body);
@@ -137,7 +137,7 @@ router.put('/:id', async (req, res) => {
 });
 
 // DELETE /api/homes/:id - Delete home
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     

--- a/backend/src/routes/inspections.ts
+++ b/backend/src/routes/inspections.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import Joi from 'joi';
 import pool from '../config/database';
 
@@ -22,7 +22,7 @@ const updateInspectionSchema = Joi.object({
 // @route   GET /api/inspections
 // @desc    Get all inspections
 // @access  Private
-router.get('/', async (req, res) => {
+router.get('/', async (req: Request, res: Response) => {
   try {
     const { status, location, page = 1, limit = 10 } = req.query;
     
@@ -92,7 +92,7 @@ router.get('/', async (req, res) => {
 // @route   GET /api/inspections/:id
 // @desc    Get inspection by ID
 // @access  Private
-router.get('/:id', async (req, res) => {
+router.get('/:id', async (req: Request, res: Response) => {
   try {
     const { rows } = await pool.query('SELECT * FROM inspections WHERE id = $1', [req.params.id]);
     
@@ -119,7 +119,7 @@ router.get('/:id', async (req, res) => {
 // @route   POST /api/inspections
 // @desc    Create new inspection
 // @access  Private
-router.post('/', async (req, res) => {
+router.post('/', async (req: Request, res: Response) => {
   try {
     const { error, value } = createInspectionSchema.validate(req.body);
     if (error) {
@@ -161,7 +161,7 @@ router.post('/', async (req, res) => {
 // @route   PUT /api/inspections/:id
 // @desc    Update inspection
 // @access  Private
-router.put('/:id', async (req, res) => {
+router.put('/:id', async (req: Request, res: Response) => {
   try {
     const { error, value } = updateInspectionSchema.validate(req.body);
     if (error) {
@@ -234,7 +234,7 @@ router.put('/:id', async (req, res) => {
 // @route   DELETE /api/inspections/:id
 // @desc    Delete inspection
 // @access  Private
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', async (req: Request, res: Response) => {
   try {
     const { rowCount } = await pool.query('DELETE FROM inspections WHERE id = $1', [req.params.id]);
     

--- a/backend/src/routes/pdf-upload.ts
+++ b/backend/src/routes/pdf-upload.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import multer from 'multer';
 import { v4 as uuidv4 } from 'uuid';
 import Joi from 'joi';
@@ -396,7 +396,7 @@ function convertTasksToDatabaseFormat(tasks: ExtractedTask[], inspectionId: stri
 }
 
 // POST /api/pdf-upload - Upload and process PDF
-router.post('/', upload.single('pdf'), async (req, res) => {
+router.post('/', upload.single('pdf'), async (req: Request, res: Response) => {
   try {
     if (!req.file) {
       return res.status(400).json({ error: 'No PDF file uploaded' });
@@ -528,7 +528,7 @@ router.post('/', upload.single('pdf'), async (req, res) => {
 });
 
 // GET /api/pdf-upload/health - Health check for PDF processing
-router.get('/health', (req, res) => {
+router.get('/health', (req: Request, res: Response) => {
   return res.status(200).json({
     status: 'OK',
     message: 'PDF upload service is running',

--- a/backend/src/routes/remediation-reports.ts
+++ b/backend/src/routes/remediation-reports.ts
@@ -1,10 +1,10 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import pool from '../config/database';
 
 const router = express.Router();
 
 // Get comprehensive remediation report
-router.get('/', async (req, res) => {
+router.get('/', async (req: Request, res: Response) => {
   try {
     // Get all tasks with their details
     const tasksQuery = `
@@ -197,7 +197,7 @@ router.get('/', async (req, res) => {
 });
 
 // Get remediation report for specific date range
-router.get('/date-range', async (req, res) => {
+router.get('/date-range', async (req: Request, res: Response) => {
   try {
     const { startDate, endDate } = req.query;
     

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import Joi from 'joi';
 
 const router = express.Router();
@@ -89,7 +89,7 @@ const generateReportSchema = Joi.object({
 // @route   GET /api/reports
 // @desc    Get all reports
 // @access  Private
-router.get('/', async (req, res) => {
+router.get('/', async (req: Request, res: Response) => {
   try {
     const { type, status, inspectionId, page = 1, limit = 10 } = req.query;
     
@@ -140,7 +140,7 @@ router.get('/', async (req, res) => {
 // @route   GET /api/reports/:id
 // @desc    Get report by ID
 // @access  Private
-router.get('/:id', async (req, res) => {
+router.get('/:id', async (req: Request, res: Response) => {
   try {
     const report = mockReports.find(r => r.id === req.params.id);
     
@@ -167,7 +167,7 @@ router.get('/:id', async (req, res) => {
 // @route   POST /api/reports/generate
 // @desc    Generate new report
 // @access  Private
-router.post('/generate', async (req, res) => {
+router.post('/generate', async (req: Request, res: Response) => {
   try {
     const { error, value } = generateReportSchema.validate(req.body);
     if (error) {
@@ -230,7 +230,7 @@ router.post('/generate', async (req, res) => {
 // @route   GET /api/reports/:id/download
 // @desc    Download report file
 // @access  Private
-router.get('/:id/download', async (req, res) => {
+router.get('/:id/download', async (req: Request, res: Response) => {
   try {
     const report = mockReports.find(r => r.id === req.params.id);
     
@@ -270,7 +270,7 @@ router.get('/:id/download', async (req, res) => {
 // @route   DELETE /api/reports/:id
 // @desc    Delete report
 // @access  Private
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', async (req: Request, res: Response) => {
   try {
     const reportIndex = mockReports.findIndex(r => r.id === req.params.id);
     

--- a/backend/src/routes/task-photos.ts
+++ b/backend/src/routes/task-photos.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import multer from 'multer';
 import { v4 as uuidv4 } from 'uuid';
 import pool from '../config/database';
@@ -26,7 +26,7 @@ const upload = multer({
 });
 
 // Upload photo for a task
-router.post('/:taskId', upload.single('photo'), async (req, res) => {
+router.post('/:taskId', upload.single('photo'), async (req: Request, res: Response) => {
   try {
     const { taskId } = req.params;
     const { photoType = 'completion', description = '' } = req.body;
@@ -94,7 +94,7 @@ router.post('/:taskId', upload.single('photo'), async (req, res) => {
 });
 
 // Get photos for a task
-router.get('/:taskId', async (req, res) => {
+router.get('/:taskId', async (req: Request, res: Response) => {
   try {
     const { taskId } = req.params;
     
@@ -114,7 +114,7 @@ router.get('/:taskId', async (req, res) => {
 });
 
 // Delete a photo
-router.delete('/:photoId', async (req, res) => {
+router.delete('/:photoId', async (req: Request, res: Response) => {
   try {
     const { photoId } = req.params;
     

--- a/backend/src/routes/task-rejections.ts
+++ b/backend/src/routes/task-rejections.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import Joi from 'joi';
 import pool from '../config/database';
 
@@ -11,7 +11,7 @@ const rejectTaskSchema = Joi.object({
 });
 
 // Reject a task
-router.post('/:taskId', async (req, res) => {
+router.post('/:taskId', async (req: Request, res: Response) => {
   try {
     const { taskId } = req.params;
     console.log('Reject task request:', { taskId, body: req.body });
@@ -86,7 +86,7 @@ router.post('/:taskId', async (req, res) => {
 });
 
 // Get rejection for a task
-router.get('/:taskId', async (req, res) => {
+router.get('/:taskId', async (req: Request, res: Response) => {
   try {
     const { taskId } = req.params;
     
@@ -111,7 +111,7 @@ router.get('/:taskId', async (req, res) => {
 });
 
 // Resolve a rejection (admin only)
-router.put('/:taskId/resolve', async (req, res) => {
+router.put('/:taskId/resolve', async (req: Request, res: Response) => {
   try {
     const { taskId } = req.params;
     const { new_status = 'pending' } = req.body;

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import Joi from 'joi';
 import pool from '../config/database';
 
@@ -25,7 +25,7 @@ const updateTaskSchema = Joi.object({
 // @route   GET /api/tasks
 // @desc    Get all tasks
 // @access  Private
-router.get('/', async (req, res) => {
+router.get('/', async (req: Request, res: Response) => {
   try {
     const { status, priority, inspectionId, home_id, page = 1, limit = 10 } = req.query;
     
@@ -100,7 +100,7 @@ router.get('/', async (req, res) => {
 // @route   GET /api/tasks/:id
 // @desc    Get task by ID
 // @access  Private
-router.get('/:id', async (req, res) => {
+router.get('/:id', async (req: Request, res: Response) => {
   try {
     const { rows } = await pool.query('SELECT * FROM tasks WHERE id = $1', [req.params.id]);
     
@@ -127,7 +127,7 @@ router.get('/:id', async (req, res) => {
 // @route   POST /api/tasks
 // @desc    Create new task
 // @access  Private
-router.post('/', async (req, res) => {
+router.post('/', async (req: Request, res: Response) => {
   try {
     const { error, value } = createTaskSchema.validate(req.body);
     if (error) {
@@ -170,7 +170,7 @@ router.post('/', async (req, res) => {
 // @route   PUT /api/tasks/:id
 // @desc    Update task
 // @access  Private
-router.put('/:id', async (req, res) => {
+router.put('/:id', async (req: Request, res: Response) => {
   try {
     const { error, value } = updateTaskSchema.validate(req.body);
     if (error) {
@@ -239,7 +239,7 @@ router.put('/:id', async (req, res) => {
 // @route   DELETE /api/tasks/:id
 // @desc    Delete task
 // @access  Private
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', async (req: Request, res: Response) => {
   try {
     const { rowCount } = await pool.query('DELETE FROM tasks WHERE id = $1', [req.params.id]);
     

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import pool from '../config/database';
 import Joi from 'joi';
 import bcrypt from 'bcryptjs';
@@ -21,7 +21,7 @@ const updateUserSchema = Joi.object({
 });
 
 // Get all users
-router.get('/', async (req, res) => {
+router.get('/', async (req: Request, res: Response) => {
   try {
     const { rows } = await pool.query(
       'SELECT id, name, email, role, created_at, updated_at FROM users ORDER BY created_at DESC'
@@ -41,7 +41,7 @@ router.get('/', async (req, res) => {
 });
 
 // Get user by ID
-router.get('/:id', async (req, res) => {
+router.get('/:id', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const { rows } = await pool.query(
@@ -70,7 +70,7 @@ router.get('/:id', async (req, res) => {
 });
 
 // Create new user
-router.post('/', async (req, res) => {
+router.post('/', async (req: Request, res: Response) => {
   try {
     const { error, value } = createUserSchema.validate(req.body);
     if (error) {
@@ -114,7 +114,7 @@ router.post('/', async (req, res) => {
 });
 
 // Update user
-router.put('/:id', async (req, res) => {
+router.put('/:id', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const { error, value } = updateUserSchema.validate(req.body);
@@ -205,7 +205,7 @@ router.put('/:id', async (req, res) => {
 });
 
 // Delete user
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
 


### PR DESCRIPTION
## Summary
- import `Request` and `Response` from express in all backend route files
- annotate route handler parameters with explicit types to avoid implicit `any`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a318c2f7e4832095262099d27591cb