### PR TITLE
chore: type home selector change event

### DIFF
--- a/frontend/src/components/HomeSelector/HomeSelector.tsx
+++ b/frontend/src/components/HomeSelector/HomeSelector.tsx
@@ -8,6 +8,7 @@ import {
   Chip,
   IconButton,
   Tooltip,
+  SelectChangeEvent,
 } from '@mui/material';
 import {
   Home as HomeIcon,
@@ -19,8 +20,8 @@ const HomeSelector: React.FC = () => {
   const { selectedHome, homes, loading, setSelectedHome } = useHome();
   const [open, setOpen] = useState(false);
 
-  const handleHomeChange = (event: any) => {
-    const homeId = event.target.value;
+  const handleHomeChange = (event: SelectChangeEvent) => {
+    const homeId = event.target.value as string;
     const home = homes.find(h => h.id === homeId);
     setSelectedHome(home || null);
   };


### PR DESCRIPTION
## Summary
- type HomeSelector `handleHomeChange` with `SelectChangeEvent`
- ensure selected home id is read as a string

## Testing
- `npm --prefix frontend test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a31c638394832085577fb35088fcf3