### PR TITLE
Add pg types to backend TypeScript config

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -21,7 +21,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "types": ["node"],
+    "types": ["node", "pg"],
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]
@@ -38,4 +38,4 @@
     "dist",
     "**/*.test.ts"
   ]
-} 
+}


### PR DESCRIPTION
## Summary
- extend backend TypeScript config to include pg ambient types

## Testing
- `cd backend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3208255e08320a3a783422127c1ce