### PR TITLE
Include dist folder in backend deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         rm -rf deployment-package deployment-package.zip
         mkdir -p deployment-package
-        cp -r backend/dist/. deployment-package/
+        cp -r backend/dist deployment-package/
         cp backend/package.json backend/package-lock.json deployment-package/
         mkdir -p deployment-package/config
         cp backend/src/config/schema.sql deployment-package/config/


### PR DESCRIPTION
## Summary
- Copy entire `backend/dist` directory into deployment package during backend deploy workflow

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ef396f9c832093925ca1a5312126